### PR TITLE
Add `requires` to job specs.

### DIFF
--- a/internal/app/cli/info.go
+++ b/internal/app/cli/info.go
@@ -26,7 +26,7 @@ var infoCmd = &cobra.Command{
 		}
 
 		// TODO: verbose output
-		fmt.Printf("ID: %s\nNAME: %s\nJOBS:\n", wf.Id, wf.Name)
+		fmt.Printf("ID: %s\nNAME: %s\nJOBS:\n", wf.ID, wf.Name)
 		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		fmt.Fprintf(tw, infoLineFmt, "NAME", "ID", "STATUS", "EXITCODE")
 		for _, j := range wf.Jobs {
@@ -34,7 +34,7 @@ var infoCmd = &cobra.Command{
 			if j.ExitCode != nil {
 				exitCode = fmt.Sprintf("%d", *j.ExitCode)
 			}
-			fmt.Fprintf(tw, infoLineFmt, j.Name, j.Id, j.Status, exitCode)
+			fmt.Fprintf(tw, infoLineFmt, j.Name, j.ID, j.Status, exitCode)
 		}
 		tw.Flush()
 	},

--- a/internal/app/cli/list.go
+++ b/internal/app/cli/list.go
@@ -44,12 +44,12 @@ var listCmd = &cobra.Command{
 				if w.FinishedAt == "" {
 					w.FinishedAt = "N/A"
 				}
-				fmt.Fprintf(tw, verboseListLineFmt, w.Name, w.Id, w.CreatedBy.Login, w.CreatedBy.Id, w.Status, w.CreatedAt, w.StartedAt, w.FinishedAt)
+				fmt.Fprintf(tw, verboseListLineFmt, w.Name, w.ID, w.CreatedBy.Login, w.CreatedBy.ID, w.Status, w.CreatedAt, w.StartedAt, w.FinishedAt)
 			}
 		} else {
 			fmt.Fprintf(tw, listLineFmt, "NAME", "ID", "STATUS")
 			for _, w := range wfs {
-				fmt.Fprintf(tw, listLineFmt, w.Name, w.Id, w.Status)
+				fmt.Fprintf(tw, listLineFmt, w.Name, w.ID, w.Status)
 			}
 		}
 		tw.Flush()

--- a/internal/pkg/compute/client.go
+++ b/internal/pkg/compute/client.go
@@ -32,7 +32,10 @@ func (c *Client) Create(ctx context.Context, spec schema.WorkflowSpec) (Workflow
 	}
 
 	m := struct {
-		schema.Workflow `graphql:"createWorkflow(spec: $workflowSpec)"`
+		Workflow struct {
+			ID   string
+			Name string
+		} `graphql:"createWorkflow(spec: $workflowSpec)"`
 	}{}
 
 	err := c.Mutate(ctx, &m, variables)
@@ -40,7 +43,7 @@ func (c *Client) Create(ctx context.Context, spec schema.WorkflowSpec) (Workflow
 		return Workflow{}, fmt.Errorf("while creating workflow: %w", err)
 	}
 
-	return convertWorkflow(m.Workflow), nil
+	return Workflow{ID: m.Workflow.ID, Name: m.Workflow.Name}, nil
 }
 
 func (c *Client) Delete(ctx context.Context, id string) (Workflow, error) {
@@ -49,7 +52,10 @@ func (c *Client) Delete(ctx context.Context, id string) (Workflow, error) {
 	}
 
 	m := struct {
-		schema.Workflow `graphql:"deleteWorkflow(id: $id)"`
+		Workflow struct {
+			ID   string
+			Name string
+		} `graphql:"deleteWorkflow(id: $id)"`
 	}{}
 
 	// TODO: gracefully catch case where the workflow does not exist
@@ -58,7 +64,7 @@ func (c *Client) Delete(ctx context.Context, id string) (Workflow, error) {
 		return Workflow{}, fmt.Errorf("while deleting workflow: %w", err)
 	}
 
-	return convertWorkflow(m.Workflow), nil
+	return Workflow{ID: m.Workflow.ID, Name: m.Workflow.Name}, nil
 }
 
 func (c *Client) Info(ctx context.Context, id string) (Workflow, error) {

--- a/internal/pkg/compute/convert.go
+++ b/internal/pkg/compute/convert.go
@@ -4,10 +4,10 @@ package compute
 
 import "github.com/sylabs/compute-cli/internal/pkg/schema"
 
-// convertWorkflow returns a populates workflow structure given a
+// convertWorkflow returns a populated workflow structure given a
 // GraphQL formated workflow structure
 func convertWorkflow(sw schema.Workflow) (w Workflow) {
-	w.Id = sw.Id
+	w.ID = sw.ID
 	w.Name = sw.Name
 	w.CreatedBy = User(sw.CreatedBy)
 	w.CreatedAt = sw.CreatedAt
@@ -15,8 +15,21 @@ func convertWorkflow(sw schema.Workflow) (w Workflow) {
 	w.FinishedAt = sw.FinishedAt
 	w.Status = sw.Status
 	for _, je := range sw.Jobs.Edges {
-		w.Jobs = append(w.Jobs, Job(je.Node))
+		w.Jobs = append(w.Jobs, convertJob(je.Node))
 	}
 
 	return w
+}
+
+// convertJob returns a populated job structure given a
+// GraphQl formated job structure
+func convertJob(sj schema.Job) (j Job) {
+	j.ID = sj.ID
+	j.Name = sj.Name
+	j.Image = sj.Image
+	j.Command = sj.Command
+	j.Status = sj.Status
+	j.ExitCode = sj.ExitCode
+
+	return j
 }

--- a/internal/pkg/compute/parser.go
+++ b/internal/pkg/compute/parser.go
@@ -4,6 +4,7 @@ package compute
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/sylabs/compute-cli/internal/pkg/schema"
 	"gopkg.in/yaml.v2"
@@ -30,7 +31,7 @@ func ParseSpec(b []byte) (schema.WorkflowSpec, error) {
 		Workflow workflowSpecIntermediate
 	}{}
 
-	if err := yaml.Unmarshal(b, &s); err != nil {
+	if err := yaml.UnmarshalStrict(b, &s); err != nil {
 		return schema.WorkflowSpec{}, err
 	}
 
@@ -45,6 +46,9 @@ func ParseSpec(b []byte) (schema.WorkflowSpec, error) {
 		j.Name = n
 		w.Jobs = append(w.Jobs, *j)
 	}
+
+	// sort slice by name to ensure deterministic specs
+	sort.Slice(w.Jobs, func(i, j int) bool { return w.Jobs[i].Name < w.Jobs[j].Name })
 
 	return w, nil
 }

--- a/internal/pkg/compute/testdata/parser/golden/dependent.json
+++ b/internal/pkg/compute/testdata/parser/golden/dependent.json
@@ -1,0 +1,27 @@
+{
+	"name": "DependentJobs",
+	"jobs": [
+		{
+			"name": "date",
+			"image": "library://alpine:latest",
+			"command": [
+				"date",
+				"\u003e",
+				"/data/time"
+			],
+			"requires": null
+		},
+		{
+			"name": "hello",
+			"image": "library://alpine:latest",
+			"command": [
+				"echo",
+				"-n",
+				"Hello, world, the time is $(cat /share/time)"
+			],
+			"requires": [
+				"date"
+			]
+		}
+	]
+}

--- a/internal/pkg/compute/testdata/parser/golden/multiple.json
+++ b/internal/pkg/compute/testdata/parser/golden/multiple.json
@@ -1,0 +1,23 @@
+{
+	"name": "MultipleJobs",
+	"jobs": [
+		{
+			"name": "date",
+			"image": "library://alpine:latest",
+			"command": [
+				"date"
+			],
+			"requires": null
+		},
+		{
+			"name": "hello",
+			"image": "library://alpine:latest",
+			"command": [
+				"echo",
+				"-n",
+				"Hello, world!"
+			],
+			"requires": null
+		}
+	]
+}

--- a/internal/pkg/compute/testdata/parser/golden/single.json
+++ b/internal/pkg/compute/testdata/parser/golden/single.json
@@ -1,0 +1,13 @@
+{
+	"name": "SingleJob",
+	"jobs": [
+		{
+			"name": "date",
+			"image": "library://alpine:latest",
+			"command": [
+				"date"
+			],
+			"requires": null
+		}
+	]
+}

--- a/internal/pkg/compute/testdata/parser/input/dependent.yaml
+++ b/internal/pkg/compute/testdata/parser/input/dependent.yaml
@@ -1,0 +1,11 @@
+version: 0.1
+workflow:
+  name: DependentJobs
+  jobs:
+    date:
+      image: library://alpine:latest
+      command: ["date", ">", "/data/time"]
+    hello:
+      image: library://alpine:latest
+      command: ["echo", "-n", "Hello, world, the time is $(cat /share/time)"]
+      requires: ["date"]

--- a/internal/pkg/compute/testdata/parser/input/multiple.yaml
+++ b/internal/pkg/compute/testdata/parser/input/multiple.yaml
@@ -1,0 +1,10 @@
+version: 0.1
+workflow:
+  name: MultipleJobs
+  jobs:
+    date: 
+      image: library://alpine:latest
+      command: ["date"]
+    hello:
+      image: library://alpine:latest
+      command: ["echo", "-n", "Hello, world!"]

--- a/internal/pkg/compute/testdata/parser/input/single.yaml
+++ b/internal/pkg/compute/testdata/parser/input/single.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 workflow:
-  name: mvp2
+  name: SingleJob
   jobs:
     date: 
       image: library://alpine:latest

--- a/internal/pkg/compute/testdata/parser/input/unknownfield.yaml
+++ b/internal/pkg/compute/testdata/parser/input/unknownfield.yaml
@@ -1,0 +1,8 @@
+version: 0.1
+workflow:
+  name: SingleJob
+  jobs:
+    date: 
+      image: library://alpine:latest
+      command: ["date"]
+      random: "field name"

--- a/internal/pkg/compute/types.go
+++ b/internal/pkg/compute/types.go
@@ -5,21 +5,22 @@ package compute
 import "fmt"
 
 type User struct {
-	Id    string
+	ID    string
 	Login string
 }
 
 type Job struct {
-	Id       string
+	ID       string
 	Name     string
 	Image    string
 	Command  []string
 	Status   string
 	ExitCode *int32
+	Requires []Job
 }
 
 type Workflow struct {
-	Id         string
+	ID         string
 	Name       string
 	CreatedBy  User
 	CreatedAt  string
@@ -34,5 +35,5 @@ type Viewer struct {
 }
 
 func (wf Workflow) String() string {
-	return fmt.Sprintf("Name: %s, ID: %s", wf.Name, wf.Id)
+	return fmt.Sprintf("Name: %s, ID: %s", wf.Name, wf.ID)
 }

--- a/internal/pkg/schema/job.go
+++ b/internal/pkg/schema/job.go
@@ -5,13 +5,14 @@ package schema
 // JobSpec is an input so it requires json struct tags to have
 // correct capitalization when used with github.com/shurcooL/graphql
 type JobSpec struct {
-	Name    string   `json:"name"`
-	Image   string   `json:"image"`
-	Command []string `json:"command"`
+	Name     string   `json:"name"`
+	Image    string   `json:"image"`
+	Command  []string `json:"command"`
+	Requires []string `json:"requires"`
 }
 
 type Job struct {
-	Id       string
+	ID       string
 	Name     string
 	Image    string
 	Command  []string

--- a/internal/pkg/schema/workflow.go
+++ b/internal/pkg/schema/workflow.go
@@ -10,12 +10,12 @@ type WorkflowSpec struct {
 }
 
 type User struct {
-	Id    string
+	ID    string
 	Login string
 }
 
 type Workflow struct {
-	Id         string
+	ID         string
 	Name       string
 	CreatedBy  User
 	CreatedAt  string


### PR DESCRIPTION
- Updates parser to accept the `requires` keyword to specify
dependencies between jobs
- Updates parser to throw an error if a spec has an invalid field
- Rename Id => ID to follow Go best practices

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>

Fixes: #2 