### PR TITLE
Interactive OAuth Login

### DIFF
--- a/internal/app/cli/cmpctl.go
+++ b/internal/app/cli/cmpctl.go
@@ -45,4 +45,5 @@ func init() {
 	CmpctlCmd.AddCommand(infoCmd)
 	CmpctlCmd.AddCommand(listCmd)
 	CmpctlCmd.AddCommand(serverInfoCmd)
+	CmpctlCmd.AddCommand(loginCmd)
 }

--- a/internal/app/cli/login.go
+++ b/internal/app/cli/login.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/sylabs/compute-cli/internal/pkg/auth"
+	"github.com/sylabs/compute-cli/internal/pkg/browse"
+	"golang.org/x/oauth2"
+)
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "login allows you to authenticate with the compute service.",
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		ts := auth.NewInteractiveTokenSource(
+			context.TODO(),
+			rand.NewSource(time.Now().UnixNano()),
+			&browse.Browser{},
+			"0oa24wwhwBWYa1T804x6", // TODO: discover from .well-known?
+			oauth2.Endpoint{
+				AuthURL:  "https://dev-930666.okta.com/oauth2/default/v1/authorize", // TODO: discover from .well-known
+				TokenURL: "https://dev-930666.okta.com/oauth2/default/v1/token",     // TODO: discover from .well-known
+			},
+			"offline_access", // TODO: request additional scopes
+		)
+		tok, err := ts.Token()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Login failed: %v", err)
+		}
+
+		// TODO: save token instead of displaying it!
+		if b, err := json.MarshalIndent(tok, "", "  "); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v", err)
+		} else {
+			fmt.Printf("token: %s\n", string(b))
+		}
+	},
+}

--- a/internal/pkg/auth/code_verifier.go
+++ b/internal/pkg/auth/code_verifier.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"math/rand"
+)
+
+// base64URLEncode returns a base64url encoding of octets, per RFC 7636 Appendix A.
+func base64URLEncode(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// CodeVerifier represents a code verifier used to implement the Proof Key for Code Exchange by
+// OAuth Public Clients specification (RFC 7636).
+type CodeVerifier struct {
+	v string
+}
+
+// NewCodeVerifier creates a new CodeVerifier as per the Proof Key for Code Exchange by OAuth
+// Public Clients specification (RFC 7636).
+//
+// Use String() to obtain the code verifier, and Challenge() to obtain the code challenge.
+func NewCodeVerifier(s rand.Source) (*CodeVerifier, error) {
+	b, err := readRandom(s, 32)
+	if err != nil {
+		return nil, err
+	}
+	cv := CodeVerifier{
+		v: base64URLEncode(b),
+	}
+	return &cv, nil
+}
+
+// String returns the code verifier as described in RFC 7636 § 4.1.
+func (cv *CodeVerifier) String() string {
+	return cv.v
+}
+
+// Challenge returns the code challenge as described in RFC 7636 § 4.2.
+func (cv *CodeVerifier) Challenge() string {
+	b := sha256.Sum256([]byte(cv.v))
+	return base64URLEncode(b[:])
+}
+
+// ChallengeMethod returns the method used to encode the code challenge.
+func (cv *CodeVerifier) ChallengeMethod() string {
+	return "S256"
+}

--- a/internal/pkg/auth/code_verifier_test.go
+++ b/internal/pkg/auth/code_verifier_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package auth
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestBase64URLEncode(t *testing.T) {
+	tests := []struct {
+		name string
+		b    []byte
+		want string
+	}{
+		{
+			"RFC7636AppendixA",
+			[]byte{3, 236, 255, 224, 193},
+			"A-z_4ME",
+		},
+		{
+			"RFC7636AppendixBChallenge",
+			[]byte{116, 24, 223, 180, 151, 153, 224, 37,
+				79, 250, 96, 125, 216, 173, 187, 186,
+				22, 212, 37, 77, 105, 214, 191, 240,
+				91, 88, 5, 88, 83, 132, 141, 121},
+			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+		},
+		{
+			"RFC7636AppendixBVerifier",
+			[]byte{19, 211, 30, 150, 26, 26, 216, 236,
+				47, 22, 177, 12, 76, 152, 46, 8,
+				118, 168, 120, 173, 109, 241, 68, 86,
+				110, 225, 137, 74, 203, 112, 249, 195},
+			"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := base64URLEncode(tt.b); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewCodeVerifier(t *testing.T) {
+	tests := []struct {
+		name                string
+		s                   rand.Source
+		wantString          string
+		wantChallenge       string
+		wantChallengeMethod string
+	}{
+		{
+			"Zero",
+			rand.NewSource(0),
+			"AZT9wvov_MBB0_8SBFtzyG5P-V_2YqXu6Cq99EotC3U",
+			"TMR15BCkWXoSftFpiR7qdK2niDmEyIZyjqZeqDmJSmE",
+			"S256",
+		},
+		{
+			"One",
+			rand.NewSource(1),
+			"Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk",
+			"hvTaLUAXmpilX93P_hNi6c0NMBUgg7p56UMD1O-1H7o",
+			"S256",
+		},
+		{
+			"Two",
+			rand.NewSource(2),
+			"L4KCy-L5aW8xRMCqTO1W29ln3CiXgGrzvtimOsoW4Ys",
+			"611TRvjV45QvNMBnhueb1bkJV8Na6cQ8n5GOZ41C3UA",
+			"S256",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cv, err := NewCodeVerifier(tt.s)
+			if err != nil {
+				t.Fatalf("failed to create code verifier: %v", err)
+			}
+			if got := cv.String(); got != tt.wantString {
+				t.Errorf("got %v, want %v", got, tt.wantString)
+			}
+			if got := cv.Challenge(); got != tt.wantChallenge {
+				t.Errorf("got %v, want %v", got, tt.wantChallenge)
+			}
+			if got := cv.ChallengeMethod(); got != tt.wantChallengeMethod {
+				t.Errorf("got %v, want %v", got, tt.wantChallengeMethod)
+			}
+		})
+	}
+}
+
+func TestCodeVerifierAndChallenge(t *testing.T) {
+	tests := []struct {
+		name                string
+		cv                  CodeVerifier
+		wantString          string
+		wantChallenge       string
+		wantChallengeMethod string
+	}{
+		{
+			"RFC7636AppendixB",
+			CodeVerifier{"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"},
+			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+			"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+			"S256",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cv.String(); got != tt.wantString {
+				t.Errorf("got %v, want %v", got, tt.wantString)
+			}
+			if got := tt.cv.Challenge(); got != tt.wantChallenge {
+				t.Errorf("got %v, want %v", got, tt.wantChallenge)
+			}
+			if got := tt.cv.ChallengeMethod(); got != tt.wantChallengeMethod {
+				t.Errorf("got %v, want %v", got, tt.wantChallengeMethod)
+			}
+		})
+	}
+}

--- a/internal/pkg/auth/interactive.go
+++ b/internal/pkg/auth/interactive.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sylabs/compute-cli/internal/pkg/browse"
+	"golang.org/x/oauth2"
+)
+
+const (
+	authPath = "/authorization/callback"
+)
+
+// BrowserOpener describes the interface to open an URL in a browser.
+type BrowserOpener interface {
+	Open(url string) error
+}
+
+type interactiveSource struct {
+	ctx        context.Context
+	rs         rand.Source
+	bo         BrowserOpener
+	clientID   string
+	endpoint   oauth2.Endpoint
+	scopes     []string
+	browser    *browse.Browser
+	listenAddr string
+	testChan   chan result // used to inject results during testing only
+}
+
+// NewInteractiveTokenSource returns a token source that allows a user to interactively log in.
+//
+// This source uses the OAuth 2.0 Authorization Code with Proof Key Code Exchange flow.
+func NewInteractiveTokenSource(ctx context.Context, rs rand.Source, bo BrowserOpener, clientID string, endpoint oauth2.Endpoint, scope ...string) oauth2.TokenSource {
+	return &interactiveSource{
+		ctx:        ctx,
+		rs:         rs,
+		bo:         bo,
+		clientID:   clientID,
+		endpoint:   endpoint,
+		scopes:     scope,
+		listenAddr: "localhost:9876",
+		testChan:   make(chan result),
+	}
+}
+
+// Token returns a token or an error. The token is obtained via interactive login using a browser
+// window.
+func (s *interactiveSource) Token() (*oauth2.Token, error) {
+	resultChan := s.testChan
+	if resultChan == nil {
+		resultChan = make(chan result)
+		defer close(resultChan)
+	}
+	state, err := newState(s.rs)
+	if err != nil {
+		return nil, err
+	}
+	cv, err := NewCodeVerifier(s.rs)
+	if err != nil {
+		return nil, err
+	}
+	sr := server{
+		conf: &oauth2.Config{
+			ClientID:    s.clientID,
+			Endpoint:    s.endpoint,
+			RedirectURL: fmt.Sprintf("http://%s%s", s.listenAddr, authPath),
+			Scopes:      s.scopes,
+		},
+		state:  state,
+		cv:     cv,
+		result: resultChan,
+	}
+
+	// Start listening for incoming connection before we open the URL to avoid a race condition.
+	hsr, err := sr.StartServer(s.listenAddr)
+	if err != nil {
+		return nil, err
+	}
+	defer hsr.Close()
+
+	// Open the URL to begin the OAuth2 flow.
+	url := sr.conf.AuthCodeURL(
+		state,
+		oauth2.AccessTypeOffline,
+		oauth2.SetAuthURLParam("code_challenge", cv.Challenge()),
+		oauth2.SetAuthURLParam("code_challenge_method", cv.ChallengeMethod()),
+	)
+	if err := s.bo.Open(url); err != nil {
+		return nil, err
+	}
+
+	// Wait until a result is received, or context cancellation.
+	select {
+	case r := <-resultChan:
+		// Need to do clean shutdown here, to ensure HTTP response has been served.
+		if err := hsr.Shutdown(s.ctx); err != nil {
+			logrus.WithError(err).Print("shutdown failed")
+		}
+		return r.tok, r.err
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	}
+}

--- a/internal/pkg/auth/interactive_test.go
+++ b/internal/pkg/auth/interactive_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/url"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+const goodClientID = "AGoodClientID"
+
+var goodScopes = []string{"one", "two"}
+var goodToken = oauth2.Token{
+	AccessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
+		"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+	TokenType:    "Bearer",
+	RefreshToken: "491GzL1WlDbMJ4-LmZokOes7lts-v89KMZ2k2f2SQFA",
+}
+
+type mockBrowserOpener struct {
+	wantValues url.Values
+	err        error
+}
+
+func (bo *mockBrowserOpener) Open(rawurl string) error {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return err
+	}
+	if got, want := u.Query(), bo.wantValues; !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("got query values %#v, want %#v", got, want)
+	}
+	return bo.err
+}
+
+func TestInteractiveSourceToken(t *testing.T) {
+	wantValues := url.Values{
+		"access_type":           []string{"offline"},
+		"client_id":             []string{goodClientID},
+		"code_challenge":        []string{"TWCwB8gObw2_ul7zTk_D4iDuRmRp8ODbC2MkqjIQyTM"},
+		"code_challenge_method": []string{"S256"},
+		"redirect_uri":          []string{"http://localhost:/authorization/callback"},
+		"response_type":         []string{"code"},
+		"scope":                 []string{strings.Join(goodScopes, " ")},
+		"state":                 []string{"AZT9wvov_MBB0_8SBFtzyG5P-V_2YqXu6Cq99EotC3U"},
+	}
+	expired, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		browserErr error
+		wantValues url.Values
+		wantErr    bool
+		wantResult *result
+	}{
+		{"OK", context.Background(), nil, wantValues, false, &result{tok: &goodToken}},
+		{"BrowserError", context.Background(), errors.New("oops"), wantValues, true, nil},
+		{"ExpiredContext", expired, nil, wantValues, true, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rs := rand.NewSource(0)
+			bo := mockBrowserOpener{
+				wantValues: tt.wantValues,
+				err:        tt.browserErr,
+			}
+			endpoint := oauth2.Endpoint{
+				AuthURL: "http://test/authorization/callback",
+			}
+
+			s := NewInteractiveTokenSource(tt.ctx, rs, &bo, goodClientID, endpoint, goodScopes...)
+			is := s.(*interactiveSource)
+			is.listenAddr = "localhost:"    // avoid port collisions during test
+			is.testChan = make(chan result) // side channel to inject result during test
+			defer close(is.testChan)
+
+			// If a result is expected, spin off a goroutine to send that over the channel. This
+			// simulates the result coming back from the callback.
+			wg := sync.WaitGroup{}
+			if tt.wantResult != nil {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					is.testChan <- *tt.wantResult
+				}()
+			}
+			defer wg.Wait() // Ensure goroutine exits before testChan is closed
+
+			// Call the token endpoint.
+			tok, err := s.Token()
+			if got := err; (got != nil) != tt.wantErr {
+				t.Fatalf("got err %v, wantErr %v", got, tt.wantErr)
+			}
+
+			// Verify token result.
+			if tt.wantResult != nil {
+				if got, want := tok, tt.wantResult.tok; !reflect.DeepEqual(got, want) {
+					t.Errorf("got result %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/pkg/auth/server.go
+++ b/internal/pkg/auth/server.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+)
+
+type result struct {
+	err error
+	tok *oauth2.Token
+}
+
+type server struct {
+	conf   *oauth2.Config
+	state  string
+	cv     *CodeVerifier
+	result chan result
+}
+
+var (
+	// ErrStateMismatch is returned with invalid state is received.
+	ErrStateMismatch = errors.New("auth: state mismatch")
+)
+
+// error replies to the request with the specified error and status code, and sends the error
+// result over the result channel.
+//
+// If err is nil, the text associated with the status code is written to w.
+func (s server) error(w http.ResponseWriter, err error, code int) {
+	s.result <- result{err: err}
+	if err != nil {
+		http.Error(w, err.Error(), code)
+	} else {
+		http.Error(w, http.StatusText(code), code)
+	}
+}
+
+// ServeHTTP handles the authorization callback.
+func (s server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Ignore anything that isn't a GET to the auth endpoint.
+	if r.URL.Path != authPath {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Verify the state parameter.
+	v, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		s.error(w, err, http.StatusInternalServerError)
+		return
+	}
+	if v.Get("state") != s.state {
+		s.error(w, ErrStateMismatch, http.StatusForbidden)
+		return
+	}
+
+	// Check whether the request was successful.
+	if errStr := v.Get("error"); errStr != "" {
+		if d := v.Get("error_description"); d != "" {
+			errStr += fmt.Sprintf(": %s", d)
+		}
+		s.error(w, errors.New(errStr), http.StatusBadRequest)
+		return
+	}
+
+	// Exchange will do the handshake to retrieve the initial access token.
+	tok, err := s.conf.Exchange(r.Context(), v.Get("code"), oauth2.SetAuthURLParam("code_verifier", s.cv.String()))
+	if err != nil {
+		s.error(w, err, http.StatusUnauthorized)
+		return
+	}
+
+	// Pass the token!
+	s.result <- result{tok: tok}
+
+	// Show succes page!
+	fmt.Fprintf(w, `
+		<p><strong>Success!</strong></p>
+		<p>You are authenticated and can now return to the CLI.</p>
+	`)
+}
+
+// StartServer starts an HTTP server. The server is guaranteed to be listening when the function
+// returns.
+func (s server) StartServer(address string) (*http.Server, error) {
+	ln, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+	hsr := http.Server{Handler: s}
+	go func() {
+		if err := hsr.Serve(ln); err != http.ErrServerClosed {
+			logrus.WithError(err).Printf("serve failed")
+		}
+	}()
+	return &hsr, nil
+}

--- a/internal/pkg/auth/server_test.go
+++ b/internal/pkg/auth/server_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+const goodState = "good"
+
+type mockOAuthServer struct {
+	wantGrantType   string
+	wantCode        string
+	wantRedirectURI string
+
+	code  int
+	token oauth2.Token
+}
+
+func (s *mockOAuthServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	v, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	if got := v.Get("grant_type"); got != s.wantGrantType {
+		http.Error(w, fmt.Sprintf("got grantType %v, want %v", got, s.wantGrantType), http.StatusBadRequest)
+		return
+	}
+	if got := v.Get("code"); got != s.wantCode {
+		http.Error(w, fmt.Sprintf("got code %v, want %v", got, s.wantCode), http.StatusBadRequest)
+		return
+	}
+	if got := v.Get("redirect_uri"); got != s.wantRedirectURI {
+		http.Error(w, fmt.Sprintf("got redirectURI %v, want %v", got, s.wantRedirectURI), http.StatusBadRequest)
+		return
+	}
+	if s.code != http.StatusOK {
+		w.WriteHeader(s.code)
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(s.token)
+	}
+}
+
+func TestServeHTTP(t *testing.T) {
+	goodValues := url.Values{
+		"state": []string{goodState},
+	}
+
+	tests := []struct {
+		name       string
+		path       string
+		method     string
+		values     url.Values
+		code       int
+		wantResult bool // If true, result expected over result chan
+		wantErr    bool // If true, result expected to contain non-nil error
+		wantCode   int  // Expected HTTP status code
+	}{
+		{
+			"BadPath",
+			"/bad",
+			http.MethodGet,
+			goodValues,
+			http.StatusOK,
+			false,
+			false,
+			http.StatusNotFound,
+		},
+		{
+			"BadMethod",
+			authPath,
+			"bad",
+			goodValues,
+			http.StatusOK,
+			false,
+			false,
+			http.StatusMethodNotAllowed,
+		},
+		{
+			"BadState",
+			authPath,
+			http.MethodGet,
+			url.Values{
+				"state": []string{"bad"},
+			},
+			http.StatusOK,
+			true,
+			true,
+			http.StatusForbidden,
+		},
+		{
+			"Error",
+			authPath,
+			http.MethodGet,
+			url.Values{
+				"state":             []string{goodState},
+				"error":             []string{"An error"},
+				"error_description": []string{"An error description"},
+			},
+			http.StatusOK,
+			true,
+			true,
+			http.StatusBadRequest,
+		},
+		{
+			"OK",
+			authPath,
+			http.MethodGet,
+			goodValues,
+			http.StatusOK,
+			true,
+			false,
+			http.StatusOK,
+		},
+		{
+			"Unauthorized",
+			authPath,
+			http.MethodGet,
+			goodValues,
+			http.StatusUnauthorized,
+			true,
+			true,
+			http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms := mockOAuthServer{
+				token: goodToken,
+				code:  tt.code,
+			}
+			authServer := httptest.NewServer(&ms)
+			defer authServer.Close()
+
+			s := server{
+				conf: &oauth2.Config{
+					ClientID: "12345678",
+					Endpoint: oauth2.Endpoint{
+						AuthURL:  authServer.URL,
+						TokenURL: authServer.URL,
+					},
+				},
+				state:  goodState,
+				cv:     &CodeVerifier{},
+				result: make(chan result),
+			}
+
+			// Build up incoming request according to test parameters.
+			url := url.URL{
+				Path:     tt.path,
+				RawQuery: tt.values.Encode(),
+			}
+			r := httptest.NewRequest(tt.method, url.String(), nil)
+			rr := httptest.NewRecorder()
+
+			// Call handler in goroutine. Results are bifricated over HTTP and via a channel.
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				s.ServeHTTP(rr, r)
+			}()
+
+			// Wait until result is received on channel, or channel is closed.
+			if tt.wantResult {
+				res := <-s.result
+				if got := res.err; (got != nil) != tt.wantErr {
+					t.Errorf("got err %v, wantErr %v", got, tt.wantErr)
+				}
+			}
+
+			// Wait until handler goroutine has returned before validating HTTP response.
+			wg.Wait()
+			if got := rr.Code; got != tt.wantCode {
+				t.Errorf("got code %v, want %v", got, tt.wantCode)
+			}
+		})
+	}
+}

--- a/internal/pkg/auth/util.go
+++ b/internal/pkg/auth/util.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package auth
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+// readRandom generates a slice of n bytes read from s.
+func readRandom(s rand.Source, n int) ([]byte, error) {
+	b := make([]byte, n)
+	if n, err := rand.New(s).Read(b); err != nil {
+		return nil, err
+	} else if n != len(b) {
+		return nil, fmt.Errorf("pkce: read unexpcted byte count (%d/%d)", len(b), n)
+	}
+	return b, nil
+}
+
+// newState reads from s and generates a state value for use in an OAuth request.
+func newState(s rand.Source) (string, error) {
+	b, err := readRandom(s, 32)
+	if err != nil {
+		return "", err
+	}
+	return base64URLEncode(b), nil
+}

--- a/internal/pkg/browse/browse.go
+++ b/internal/pkg/browse/browse.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package browse
+
+// Browser represents a web browser.
+type Browser struct{}

--- a/internal/pkg/browse/browse_darwin.go
+++ b/internal/pkg/browse/browse_darwin.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package browse
+
+import (
+	"os/exec"
+)
+
+// Open opens url in a browser.
+func (*Browser) Open(url string) error {
+	return exec.Command("open", url).Start()
+}

--- a/internal/pkg/browse/browse_linux.go
+++ b/internal/pkg/browse/browse_linux.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package browse
+
+import (
+	"os/exec"
+)
+
+// Open opens url in a browser.
+func (*Browser) Open(url string) error {
+	return exec.Command("xdg-open", url).Start()
+}

--- a/internal/pkg/browse/browse_windows.go
+++ b/internal/pkg/browse/browse_windows.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package browse
+
+import (
+	"os/exec"
+)
+
+// Open opens url in a browser.
+func (*Browser) Open(url string) error {
+	return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+}


### PR DESCRIPTION
Implement `login` command that allows a user to interactively login. At the moment, this only displays returned tokens, and doesn't save them or otherwise pass them to the server side.