### PR TITLE
Client Credentials Flow

### DIFF
--- a/internal/app/cli/cmpctl.go
+++ b/internal/app/cli/cmpctl.go
@@ -66,7 +66,15 @@ var CmpctlCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("Failed to get active remote: %w", err)
 		}
-		tokenSrc = r.GetOAuth2Config().TokenSource(ctx, r.GetToken())
+
+		switch t := r.GetAuthType(); t {
+		case config.AuthConfigTypeAuthCodePKCE:
+			tokenSrc = r.GetAuthCodePKCEConfig().TokenSource(ctx, r.GetToken())
+		case config.AuthConfigTypeClientCredentials:
+			tokenSrc = r.GetClientCredentialsConfig().TokenSource(ctx)
+		default:
+			return fmt.Errorf("Unknown auth configuration type: %v", t)
+		}
 
 		// initialize global client for subcommands to leverage
 		c = compute.NewClient(ctx, tokenSrc, httpAddr)

--- a/internal/app/cli/login.go
+++ b/internal/app/cli/login.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/sylabs/compute-cli/internal/pkg/auth"
 	"github.com/sylabs/compute-cli/internal/pkg/browse"
+	"github.com/sylabs/compute-cli/internal/pkg/config"
 	"golang.org/x/oauth2"
 )
 
@@ -22,7 +23,7 @@ var loginCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := ar.GetOAuth2Config()
+		c := ar.GetAuthCodePKCEConfig()
 		c.Scopes = []string{"offline_access"} // TODO: request additional scopes
 
 		// Do interactive login.
@@ -31,6 +32,7 @@ var loginCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		ar.SetAuthType(config.AuthConfigTypeAuthCodePKCE)
 
 		// Update token source to specify the newly obtained token.
 		tokenSrc = oauth2.StaticTokenSource(tok)

--- a/internal/pkg/auth/client_credentials.go
+++ b/internal/pkg/auth/client_credentials.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package auth
+
+import (
+	"context"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+type clientCredentialsSource struct {
+	ctx context.Context
+	oc  *clientcredentials.Config
+}
+
+// NewClientCredentialsSource returns a token source that uses the supplied client credentials.
+//
+// This source uses the OAuth 2.0 Client Credentials flow.
+func NewClientCredentialsSource(ctx context.Context, oc *clientcredentials.Config) oauth2.TokenSource {
+	return &clientCredentialsSource{ctx: ctx, oc: oc}
+}
+
+// Token returns a token or an error. The token is obtained via the OAuth 2.0 Client Credentials
+// flow.
+func (s *clientCredentialsSource) Token() (*oauth2.Token, error) {
+	return s.oc.Token(s.ctx)
+}

--- a/internal/pkg/config/auth_config.go
+++ b/internal/pkg/config/auth_config.go
@@ -3,19 +3,57 @@
 package config
 
 import (
+	"fmt"
+
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+const (
+	// AuthConfigTypeAuthCodePKCE represents the OAuth 2.0 Authorization Code Grant with Proof Key
+	// for Code Exchange (PKCE) flow.
+	AuthConfigTypeAuthCodePKCE = "AuthCodePKCE"
+	// AuthConfigTypeClientCredentials represents the OAuth 2.0 Client Credentials flow.
+	AuthConfigTypeClientCredentials = "ClientCredentials"
 )
 
 // authConfig describes authentication and authorization configuration.
 type authConfig struct {
-	ClientID         string `yaml:"clientId,omitempty"`         // OAuth 2.0 Client ID
+	Type             string `yaml:"type"`                       // Auth type ("AuthCodePKCE" or "ClientCredentials")
+	ClientID         string `yaml:"clientId,omitempty"`         // OAuth 2.0 client ID
+	ClientSecret     string `yaml:"clientSecret,omitempty"`     // OAuth 2.0 client secret
 	AuthURL          string `yaml:"authUrl,omitempty"`          // OAuth 2.0 authorization endpoint
 	TokenURL         string `yaml:"tokenUrl,omitempty"`         // OAuth 2.0 token endpoint
 	LoginRedirectURL string `yaml:"loginRedirectUrl,omitempty"` // OAuth 2.0 login redirect endpoint
 }
 
-// GetOAuth2Config gets the OAuth 2.0 configuration for remote r.
-func (r *remote) GetOAuth2Config() *oauth2.Config {
+// GetAuthType returns the auth type.
+func (r *remote) GetAuthType() string {
+	switch r.AuthConfig.Type {
+	case AuthConfigTypeClientCredentials:
+		return AuthConfigTypeClientCredentials
+	case AuthConfigTypeAuthCodePKCE:
+		fallthrough
+	default:
+		return AuthConfigTypeAuthCodePKCE
+	}
+}
+
+// SetAuthType sets the auth type.
+func (r *remote) SetAuthType(s string) error {
+	switch s {
+	case AuthConfigTypeClientCredentials:
+		fallthrough
+	case AuthConfigTypeAuthCodePKCE:
+		r.AuthConfig.Type = s
+	default:
+		return fmt.Errorf("Unknown auth type: %v", s)
+	}
+	return nil
+}
+
+// GetAuthCodePKCEConfig gets the OAuth 2.0 configuration for remote r.
+func (r *remote) GetAuthCodePKCEConfig() *oauth2.Config {
 	return &oauth2.Config{
 		ClientID: r.AuthConfig.ClientID,
 		Endpoint: oauth2.Endpoint{
@@ -23,5 +61,14 @@ func (r *remote) GetOAuth2Config() *oauth2.Config {
 			TokenURL: r.AuthConfig.TokenURL,
 		},
 		RedirectURL: r.AuthConfig.LoginRedirectURL,
+	}
+}
+
+// GetClientCredentialsConfig gets the OAuth 2.0 configuration for remote r.
+func (r *remote) GetClientCredentialsConfig() *clientcredentials.Config {
+	return &clientcredentials.Config{
+		ClientID:     r.AuthConfig.ClientID,
+		ClientSecret: r.AuthConfig.ClientSecret,
+		TokenURL:     r.AuthConfig.TokenURL,
 	}
 }

--- a/internal/pkg/config/auth_token.go
+++ b/internal/pkg/config/auth_token.go
@@ -24,10 +24,7 @@ func (r *remote) SetToken(t *oauth2.Token) error {
 		r.AuthToken.RefreshToken = t.RefreshToken
 		r.AuthToken.Expiry = t.Expiry
 	} else {
-		r.AuthToken.AccessToken = ""
-		r.AuthToken.TokenType = ""
-		r.AuthToken.RefreshToken = ""
-		r.AuthToken.Expiry = time.Time{}
+		r.AuthToken = authToken{}
 	}
 	return nil
 }

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -31,6 +31,7 @@ func Default() (*Config, error) {
 				"default": {
 					BaseURI: "http://localhost:8080",
 					AuthConfig: authConfig{
+						Type:             AuthConfigTypeAuthCodePKCE,
 						ClientID:         "0oa24wwhwBWYa1T804x6",
 						AuthURL:          "https://dev-930666.okta.com/oauth2/default/v1/authorize",
 						TokenURL:         "https://dev-930666.okta.com/oauth2/default/v1/token",

--- a/internal/pkg/config/remote.go
+++ b/internal/pkg/config/remote.go
@@ -2,11 +2,18 @@
 
 package config
 
-import "golang.org/x/oauth2"
+import (
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
 
 // Remote defines the operations that can be performed on a remote config.
 type Remote interface {
-	GetOAuth2Config() *oauth2.Config
+	GetAuthType() string
+	SetAuthType(string) error
+
+	GetAuthCodePKCEConfig() *oauth2.Config
+	GetClientCredentialsConfig() *clientcredentials.Config
 
 	GetToken() *oauth2.Token
 	SetToken(t *oauth2.Token) error


### PR DESCRIPTION
Introduce secondary auth flow based on the [OAuth 2.0 Client Credentials Grant](https://tools.ietf.org/html/rfc6749#section-4.4).

To test, you will need to obtain a client ID and secret. To do this with Okta:

- Log in to the [Okta dev console](https://dev-930666-admin.okta.com/dev/console)
- Click on `Applications` and then `Add Application`
- Select `Service`, and click next
- Give it a name and click `Done`
- Copy the `Client ID` and `Client secret ` fields, and place then in a config file:
  ```yaml
  remotes:
    default:
        baseUri: http://localhost:8080
        authConfig:
            type: ClientCredentials
            clientId: <Client ID>
            clientSecret: <Client secret>
            tokenUrl: https://dev-930666.okta.com/oauth2/default/v1/token
  ```
- Run a command, such as `list`. Note that `login` is not required (and will overwrite the config with an `AuthCodePKCE` type.)