### PR TITLE
CLI: add version command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sylabs/fuzzctl
 go 1.13
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-git/go-git/v5 v5.0.0
 	github.com/goreleaser/nfpm v1.2.1
 	github.com/magefile/mage v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,9 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb h1:m935MPodAbYS46DG4pJSv7WO+VECIWUQ7OJYSoTrMh4=
 github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
+github.com/blang/semver v1.1.0 h1:ol1rO7QQB5uy7umSNV7VAmLugfLRD+17sYJujRNYPhg=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e h1:hHg27A0RSSp2Om9lubZpiMgVbvn39bsUmW9U5h0twqc=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/internal/app/cli/fuzzctl.go
+++ b/internal/app/cli/fuzzctl.go
@@ -20,6 +20,12 @@ var (
 
 	tokenSrc oauth2.TokenSource
 	cfg      *config.Config
+
+	// Values set during build.
+	gitVersion   = "unknown"
+	gitCommit    = "unknown"
+	gitTreeState = "unknown"
+	builtAt      = "unknown"
 )
 
 // fuzzctl flag variables
@@ -156,4 +162,5 @@ func init() {
 	FuzzctlCmd.AddCommand(listCmd)
 	FuzzctlCmd.AddCommand(loginCmd)
 	FuzzctlCmd.AddCommand(logoutCmd)
+	FuzzctlCmd.AddCommand(versionCmd)
 }

--- a/internal/app/cli/version.go
+++ b/internal/app/cli/version.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/sylabs/fuzzctl/internal/pkg/client"
+)
+
+func buildInfoToJSON(bi client.BuildInfo) (string, error) {
+	b := &bytes.Buffer{}
+	if err := json.NewEncoder(b).Encode(bi); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information.",
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		// Client version.
+		bi := client.BuildInfo{
+			GitVersion:   gitVersion,
+			GitCommit:    gitCommit,
+			GitTreeState: gitTreeState,
+			BuiltAt:      builtAt,
+			GoVersion:    runtime.Version(),
+			Compiler:     runtime.Compiler,
+			Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		}
+		if s, err := buildInfoToJSON(bi); err == nil {
+			fmt.Printf("Client version: %v", s)
+		} else {
+			logrus.WithError(err).Warn("failed to convert client version")
+		}
+
+		// Server version.
+		if bi, err := c.ServerBuildInfo(context.Background()); err == nil {
+			if s, err := buildInfoToJSON(bi); err == nil {
+				fmt.Printf("Server version: %v", s)
+			} else {
+				logrus.WithError(err).Warn("failed to convert server version")
+			}
+		} else {
+			logrus.WithError(err).Warn("failed to get server version")
+		}
+	},
+}

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -104,3 +104,15 @@ func (c *Client) List(ctx context.Context) ([]Workflow, error) {
 
 	return wfs, nil
 }
+
+// ServerBuildInfo retrieves build information about the server.
+func (c *Client) ServerBuildInfo(ctx context.Context) (BuildInfo, error) {
+	q := struct {
+		schema.BuildInfo `graphql:"serverBuildInfo"`
+	}{}
+
+	if err := c.Query(ctx, &q, nil); err != nil {
+		return BuildInfo{}, err
+	}
+	return convertBuildInfo(q.BuildInfo), nil
+}

--- a/internal/pkg/client/convert.go
+++ b/internal/pkg/client/convert.go
@@ -2,7 +2,13 @@
 
 package client
 
-import "github.com/sylabs/fuzzctl/internal/pkg/schema"
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sylabs/fuzzctl/internal/pkg/schema"
+)
 
 // convertWorkflow returns a populated workflow structure given a
 // GraphQL formated workflow structure
@@ -33,4 +39,39 @@ func convertJob(sj schema.Job) (j Job) {
 	j.Output = sj.Output
 
 	return j
+}
+
+func convertBuildInfo(sbi schema.BuildInfo) BuildInfo {
+	bi := BuildInfo{
+		GitVersion:   "unknown",
+		GitCommit:    "unknown",
+		GitTreeState: "unknown",
+		BuiltAt:      "unknown",
+		GoVersion:    sbi.GoVersion,
+		Compiler:     sbi.Compiler,
+		Platform:     sbi.Platform,
+	}
+
+	if v := sbi.GitVersion; v != nil {
+		b := &strings.Builder{}
+		fmt.Fprintf(b, "%v.%v.%v", v.Major, v.Minor, v.Patch)
+		if v.PreRelease != nil {
+			fmt.Fprintf(b, "-%v", *v.PreRelease)
+		}
+		if v.BuildMetadata != nil {
+			fmt.Fprintf(b, "+%v", *v.BuildMetadata)
+		}
+		bi.GitVersion = b.String()
+	}
+	if c := sbi.GitCommit; c != nil {
+		bi.GitCommit = *c
+	}
+	if s := sbi.GitTreeState; s != nil {
+		bi.GitTreeState = *s
+	}
+	if t := sbi.BuiltAt; t != nil {
+		bi.BuiltAt = t.Format(time.RFC3339)
+	}
+
+	return bi
 }

--- a/internal/pkg/client/round_tripper.go
+++ b/internal/pkg/client/round_tripper.go
@@ -5,6 +5,9 @@ package client
 import "net/http"
 
 func setUserAgent(rt http.RoundTripper, agent string) http.RoundTripper {
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
 	return &uaRT{
 		rt:    rt,
 		agent: agent,

--- a/internal/pkg/client/types.go
+++ b/internal/pkg/client/types.go
@@ -2,7 +2,11 @@
 
 package client
 
-import "fmt"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
 
 type User struct {
 	ID    string
@@ -37,4 +41,24 @@ type Viewer struct {
 
 func (wf Workflow) String() string {
 	return fmt.Sprintf("Name: %s, ID: %s", wf.Name, wf.ID)
+}
+
+// BuildInfo represents build information about a component.
+type BuildInfo struct {
+	GitVersion   string `json:"gitVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuiltAt      string `json:"builtAt"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+}
+
+// String returns the string representation of bi.
+func (bi BuildInfo) String() string {
+	b := &bytes.Buffer{}
+	if err := json.NewEncoder(b).Encode(bi); err != nil {
+		return ""
+	}
+	return b.String()
 }

--- a/internal/pkg/schema/version.go
+++ b/internal/pkg/schema/version.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+package schema
+
+import "time"
+
+// BuildInfo represents build information about a component.
+type BuildInfo struct {
+	GitVersion   *Version   `json:"gitVersion"`
+	GitCommit    *string    `json:"gitCommit"`
+	GitTreeState *string    `json:"gitTreeState"`
+	BuiltAt      *time.Time `json:"builtAt"`
+	GoVersion    string     `json:"goVersion"`
+	Compiler     string     `json:"compiler"`
+	Platform     string     `json:"platform"`
+}
+
+// Version represents semantic version information.
+type Version struct {
+	Major         int32   `json:"major"`
+	Minor         int32   `json:"minor"`
+	Patch         int32   `json:"patch"`
+	PreRelease    *string `json:"preRelease"`
+	BuildMetadata *string `json:"buildMetadata"`
+}

--- a/magefile.go
+++ b/magefile.go
@@ -5,23 +5,56 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+	"github.com/sirupsen/logrus"
 )
+
+// ldFlags returns standard linker flags to pass to various Go commands.
+func ldFlags() string {
+	pkgPath := "github.com/sylabs/fuzzctl/internal/app/cli"
+	vals := []string{
+		fmt.Sprintf("-X %v.builtAt=%v", pkgPath, time.Now().UTC().Format(time.RFC3339)),
+	}
+
+	// Attempt to get git details.
+	d, err := describeHead()
+	if err == nil {
+		vals = append(vals, fmt.Sprintf("-X %v.gitCommit=%v", pkgPath, d.ref.Hash().String()))
+
+		if d.isClean {
+			vals = append(vals, fmt.Sprintf("-X %v.gitTreeState=clean", pkgPath))
+		} else {
+			vals = append(vals, fmt.Sprintf("-X %v.gitTreeState=dirty", pkgPath))
+		}
+
+		if v, err := getVersion(d); err != nil {
+			logrus.WithError(err).Warn("failed to get version from git description")
+		} else {
+			vals = append(vals, fmt.Sprintf("-X %v.gitVersion=%v", pkgPath, v.String()))
+		}
+	}
+
+	return strings.Join(vals, " ")
+}
 
 // Build builds fuzzctl using `go build`.
 func Build() error {
-	return sh.RunV(mg.GoCmd(), "build", "./cmd/fuzzctl")
+	return sh.RunV(mg.GoCmd(), "build", "-ldflags", ldFlags(), "./cmd/fuzzctl")
 }
 
 // Install installs fuzzctl using `go install`.
 func Install() error {
-	return sh.RunV(mg.GoCmd(), "install", "./cmd/fuzzctl")
+	return sh.RunV(mg.GoCmd(), "install", "-ldflags", ldFlags(), "./cmd/fuzzctl")
 }
 
 // Test runs unit tests using `go test`.
 func Test() error {
-	return sh.RunV(mg.GoCmd(), "test", "-cover", "-race", "./...")
+	return sh.RunV(mg.GoCmd(), "test", "-ldflags", ldFlags(), "-cover", "-race", "./...")
 }
 
 // Deb builds a deb package.

--- a/nfpm.go
+++ b/nfpm.go
@@ -19,7 +19,12 @@ func getPackageInfo(c nfpm.Config, format string) (*nfpm.Info, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.Version = d.String()
+
+	v, err := getVersion(d)
+	if err != nil {
+		return nil, err
+	}
+	c.Version = v.String()
 
 	info, err := c.Get(format)
 	if err != nil {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2020, Sylabs, Inc. All rights reserved.
+
+// +build mage
+
+package main
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/blang/semver"
+)
+
+// getVersion returns a semantic version based on d.
+func getVersion(d *gitDescription) (semver.Version, error) {
+	if d.tag == nil {
+		return semver.Version{}, errors.New("no semver tags found")
+	}
+
+	v, err := semver.Parse(strings.TrimPrefix(d.tag.Name, "v"))
+	if err != nil {
+		return semver.Version{}, err
+	}
+
+	// If this version wasn't tagged directly, modify tag.
+	if d.n > 0 {
+		if len(v.Pre) == 0 {
+			// The tag is not a pre-release version. Bump the patch version and add a pre-release
+			// of alpha.0. Semantically, this indicates this is pre-alpha.1, which would normally
+			// be the first alpha version.
+			v.Patch += 1
+			v.Pre = append(v.Pre, semver.PRVersion{VersionStr: "alpha"})
+			v.Pre = append(v.Pre, semver.PRVersion{VersionNum: 0, IsNum: true})
+		}
+
+		// Append devel.N to pre-release version. For example, if the tag is 0.1.2-alpha.1, tag as
+		// 0.1.2-alpha.1.devel.3. Semantically, this indicates this version is between alpha.1 and
+		// alpha.2.
+		v.Pre = append(v.Pre, semver.PRVersion{VersionStr: "devel"})
+		v.Pre = append(v.Pre, semver.PRVersion{VersionNum: d.n, IsNum: true})
+	}
+
+	return v, nil
+}


### PR DESCRIPTION
Improve Magefile versioning. Add `version` command, which displays client and service version information. Fix panic in `setUserAgent()` when `nil` `http.Transport` used.